### PR TITLE
Arch support

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Dimitri Bonanni-Surprenant <bond2102@usherbrooke.ca>
+pkgname=unitex
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="A collection of scientific oriented and minimalistic LaTeX templates suitable for many assignment types"
+arch=("x86_64")
+url="https://github.com/BCarnaval/UniTeX"
+license=('MIT')
+groups=()
+depends=("rsync")
+makedepends=()
+optdepends=()
+provides=()
+conflicts=()
+replaces=()
+backup=()
+options=()
+install=
+changelog=
+source=($pkgname-$pkgver.tar.gz)
+noextract=()
+sha256sums=('14eb7b9461c5eb1328c2eb48f44e459825484802bea4f6f52e770c93d02e4e23')
+
+build() {
+	echo "$PWD"
+	cd "UniTeX"
+
+	chmod +x install.sh
+	./install.sh
+}
+
+package() {
+	cd "UniTeX"
+
+	make DESTDIR="$pkgdir" install
+}

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ LINK_DIR=/usr/local/bin/unitex
 MAN_DIR=/usr/local/share/man
 
 # Turn on extended globbing in bash shell
-shopt -s extglob 
+shopt -s extglob
 
 reset_terminal () {
     tput sgr0
@@ -34,7 +34,7 @@ check_rsync () {
                     if [[ ${OS} = 'Darwin' ]]; then
                         brew install --quiet rsync
                     elif [[ ${OS} = 'Linux' ]]; then
-                        sudo apt-get install -qq rsync
+                        sudo apt-get install -qq rsync  # Tssss Debian Exclusive
                     fi
                     echo -e "\n${GREEN}[@] Installation done!"
                     break
@@ -51,7 +51,7 @@ check_rsync () {
 }
 
 use_viewer () {
-    if command -v zathura &> /dev/null; then 
+    if command -v zathura &> /dev/null; then
         echo -e "${WHITE}--------------------------\n"
         echo -e "${GREEN}[@] This pdf viewer has been found on your system: \n${WHITE}$(zathura -v)"
 
@@ -87,7 +87,7 @@ build_directory () {
         # Updating directories
         echo -e "${GREEN}[@] Wiping old version if any inside ${WHITE}${DESTINATION}${GREEN}."
         sudo rm -rf ${DESTINATION}/${PROJ}
-        
+
         if [[ "${OS}" = "Darwin" ]]; then
             sudo rm ${MAN_DIR}/man1/unitex.1
         else


### PR DESCRIPTION
Added PKGBUILD for arch support
For arch:
- Package is not stable, the install should be configurable from config file (directory and all), perhaps switch to a make install
- Package name is not compatible with the arch guidelines for a package; cannot publish the PKGBUILD yet